### PR TITLE
Add enpoint to create user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ MIGRATE_DB_PASSWORD := postgres
 MIGRATE_DB_URL := jdbc:postgresql://postgres/akkaapitemplate
 
 PROTO_REPOSITORY = nykolaslima/akka-api-template-resources
-PROTO_VERSION = v1.0.0
+PROTO_VERSION = v1.2.0
 PROTOS_PATH = tmp/resources
 RESOURCES_PATH = src/main/generated-proto
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,11 @@ lazy val kamonDependencies = Seq(
   "org.aspectj" % "aspectjweaver" % "1.8.10"
 )
 
+lazy val validation = Seq(
+  "org.typelevel" %% "cats" % "0.4.0",
+  "com.osinka.i18n" %% "scala-i18n" % "1.0.0"
+)
+
 libraryDependencies ++= (
   commonDependencies ++
     akkaDependencies ++
@@ -65,5 +70,6 @@ libraryDependencies ++= (
     akkaComplementsDependencies ++
     databaseDependencies ++
     googleDependencies ++
-    kamonDependencies
+    kamonDependencies ++
+    validation
   )

--- a/src/main/resources/messages.txt
+++ b/src/main/resources/messages.txt
@@ -1,0 +1,3 @@
+validation.required {0} é obrigatório
+
+user.name Nome

--- a/src/main/scala/com/akkaapitemplate/components/user/ActorMessages.scala
+++ b/src/main/scala/com/akkaapitemplate/components/user/ActorMessages.scala
@@ -9,5 +9,6 @@ object ActorMessages {
   }
 
   case class LoadById(override val requestId: UUID, originalSender: Option[ActorRef] = None, id: UUID) extends HttpMessage
+  case class Create(override val requestId: UUID, originalSender: Option[ActorRef] = None, user: User) extends HttpMessage
   case class Fail(cause: Throwable)
 }

--- a/src/main/scala/com/akkaapitemplate/components/user/UserRepository.scala
+++ b/src/main/scala/com/akkaapitemplate/components/user/UserRepository.scala
@@ -1,5 +1,6 @@
 package com.akkaapitemplate.components.user
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 import com.akkaapitemplate.infrastructure.persistence.postgres.DBConnection
@@ -12,6 +13,12 @@ trait UserRepository extends DBConnection {
   def loadById(id: UUID): Future[Option[User]] = {
     val query = table.filter(_.uuid === id).result.headOption
     run(query)
+  }
+
+  def add(user: User): Future[User] = {
+    val userToAdd = user.copy(id = Some(UUID.randomUUID))
+    val query = table += userToAdd
+    run(query).map(_ => userToAdd)
   }
 }
 

--- a/src/main/scala/com/akkaapitemplate/components/user/UserRoute.scala
+++ b/src/main/scala/com/akkaapitemplate/components/user/UserRoute.scala
@@ -4,14 +4,15 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.pattern.ask
 import akka.util.Timeout
-import com.akkaapitemplate.components.user.ActorMessages.LoadById
+import com.akkaapitemplate.components.user.ActorMessages.{Create, LoadById}
 import com.akkaapitemplate.infrastructure.logs.GelfLogger
 import com.akkaapitemplate.infrastructure.routes.ApplicationRoute
-import com.akkaapitemplate.resources.UserResource
+import com.akkaapitemplate.infrastructure.validation.Rejection
+import com.akkaapitemplate.resources.{ErrorResource, RejectionResource, RejectionsResource, UserResource}
 import org.slf4j.LoggerFactory
 
 trait UserRoute extends ApplicationRoute {
@@ -19,39 +20,74 @@ trait UserRoute extends ApplicationRoute {
   implicit val timeout = Timeout(1.second)
 
   val log = LoggerFactory.getLogger(this.getClass)
-
   val userServiceActor = actorSystem.actorOf(UserServiceActor.props, "user-service-actor")
 
   val routes = {
-    pathPrefix("users" / JavaUUID) { id =>
-      get {
-        extractRequestId { requestId =>
-          val actorResponse = (userServiceActor ? LoadById(requestId = requestId, id = id)).mapTo[Option[User]]
+    path("users") {
+      extractRequestId { requestId =>
+        post {
+          entity(as[UserResource]) { resource =>
+            val user = User(None, resource.name)
+            val actorResponse = (userServiceActor ? Create(requestId = requestId, user = user)).mapTo[Either[List[Rejection], User]]
 
-          onComplete(actorResponse) {
-            case Success(userOpt) => {
-              userOpt match {
-                case Some(user) =>
-                  log.info(GelfLogger.buildWithRequestId(requestId).info("User retrieved successfully"))
-                  val resource = UserResource(user.id.get.toString, user.name)
-                  complete((StatusCodes.OK, resource))
+            onComplete(actorResponse) {
+              case Success(result) =>
+                result match {
+                  case Right(addedUser) =>
+                    log.info(GelfLogger.buildWithRequestId(requestId).info("User added successfully"))
+                    val resource = UserResource(addedUser.id.get.toString, addedUser.name)
+                    complete((Created, resource))
 
-                case None =>
-                  log.info(GelfLogger.buildWithRequestId(requestId).info("User not found"))
-                  complete(StatusCodes.NotFound)
-              }
-            }
+                  case Left(rejections) =>
+                    def toResource(rejection: Rejection): RejectionResource = RejectionResource(
+                      rejection.category.toString,
+                      rejection.target,
+                      rejection.message,
+                      rejection.key,
+                      rejection.args.map(_.toString)
+                    )
+                    val resource = RejectionsResource(rejections.map(toResource))
+                    complete((BadRequest, resource))
+                }
 
-            case Failure(e) => {
-              log.error(GelfLogger.buildWithRequestId(requestId)
-                .error(message = s"Error fetching user: ${e.getMessage}", fullMessage = Some(e.toString)))
+              case Failure(e) =>
+                log.error(GelfLogger.buildWithRequestId(requestId)
+                  .error(message = s"Error adding user: ${e.getMessage}", fullMessage = Some(e.toString)))
 
-              complete((StatusCodes.InternalServerError, e.getMessage))
+                complete((InternalServerError, ErrorResource(requestId.toString, e.getMessage)))
             }
           }
         }
       }
-    }
+    } ~
+      path("users" / JavaUUID) { id =>
+        extractRequestId { requestId =>
+          get {
+            val actorResponse = (userServiceActor ? LoadById(requestId = requestId, id = id)).mapTo[Option[User]]
 
+            onComplete(actorResponse) {
+              case Success(userOpt) => {
+                userOpt match {
+                  case Some(user) =>
+                    log.info(GelfLogger.buildWithRequestId(requestId).info("User retrieved successfully"))
+                    val resource = UserResource(user.id.get.toString, user.name)
+                    complete((OK, resource))
+
+                  case None =>
+                    log.info(GelfLogger.buildWithRequestId(requestId).info("User not found"))
+                    complete(NotFound)
+                }
+              }
+
+              case Failure(e) => {
+                log.error(GelfLogger.buildWithRequestId(requestId)
+                  .error(message = s"Error fetching user: ${e.getMessage}", fullMessage = Some(e.toString)))
+
+                complete((InternalServerError, ErrorResource(requestId.toString, e.getMessage)))
+              }
+            }
+          }
+        }
+      }
   }
 }

--- a/src/main/scala/com/akkaapitemplate/components/user/UserServiceActor.scala
+++ b/src/main/scala/com/akkaapitemplate/components/user/UserServiceActor.scala
@@ -1,13 +1,15 @@
 package com.akkaapitemplate.components.user
 
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
+import scala.util.Left
+
 import akka.actor.SupervisorStrategy._
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
 import akka.event.LoggingReceive
-import com.akkaapitemplate.components.user.ActorMessages.LoadById
+import com.akkaapitemplate.components.user.ActorMessages.{Create, LoadById}
 import com.akkaapitemplate.infrastructure.logs.ApplicationError._
 import com.akkaapitemplate.infrastructure.logs.GelfLogger
 
-class UserServiceActor(repositoryRef: Option[ActorRef] = None) extends Actor with ActorLogging {
+class UserServiceActor(repositoryRef: Option[ActorRef] = None, userValidator: UserValidator = UserValidator) extends Actor with ActorLogging {
   override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
     case _: java.sql.SQLTimeoutException => Restart
     case _: org.postgresql.util.PSQLException => Stop
@@ -23,6 +25,22 @@ class UserServiceActor(repositoryRef: Option[ActorRef] = None) extends Actor wit
 
       userRepositoryActor forward loadById
 
+    case create @ Create(requestId, originalSender, user) =>
+      val replyTo = originalSender.getOrElse(sender())
+
+      log.info(GelfLogger.buildWithRequestId(requestId)
+        .info(s"Create - Validating user: $user"))
+      userValidator.validate(user) match {
+        case Nil =>
+          log.info(GelfLogger.buildWithRequestId(requestId)
+            .info(s"Create - Forwarding user: $user to create"))
+          userRepositoryActor forward create
+
+        case rejections =>
+          log.info(GelfLogger.buildWithRequestId(requestId)
+            .info(s"Create - Replying rejections: $user to sender"))
+          replyTo ! Left(rejections)
+      }
     case Terminated(actorRef) =>
       log.error(GelfLogger.error("Stopping watcher, actor is now dead, re-creating it.",
         Map("internal_operation" -> ACTOR_DEAD)))

--- a/src/main/scala/com/akkaapitemplate/components/user/UserValidator.scala
+++ b/src/main/scala/com/akkaapitemplate/components/user/UserValidator.scala
@@ -1,0 +1,15 @@
+package com.akkaapitemplate.components.user
+
+import com.akkaapitemplate.infrastructure.validation.{Rejection, Rule, ValidationRules, Validator}
+
+trait UserValidator extends ValidationRules {
+  def validate(user: User): List[Rejection] = {
+    val rules: List[Rule[User]] = List(
+      Rule(notEmpty(user.name, "user.name"))
+    )
+
+    Validator.validate(user, rules)
+  }
+}
+
+object UserValidator extends UserValidator

--- a/src/main/scala/com/akkaapitemplate/infrastructure/routes/ApplicationRoute.scala
+++ b/src/main/scala/com/akkaapitemplate/infrastructure/routes/ApplicationRoute.scala
@@ -1,5 +1,10 @@
 package com.akkaapitemplate.infrastructure.routes
 
 import com.akkaapitemplate.infrastructure.serialization.ApplicationMarshalling
+import com.akkaapitemplate.resources.{ErrorResource, RejectionsResource, UserResource}
 
-trait ApplicationRoute extends ApplicationMarshalling with RequestIdDirective
+trait ApplicationRoute extends ApplicationMarshalling with RequestIdDirective {
+  implicit val userUnmarshaller = scalaPBFromRequestUnmarshaller(UserResource)
+  implicit val rejectionsUnmarshaller = scalaPBFromRequestUnmarshaller(RejectionsResource)
+  implicit val errorUnmarshaller = scalaPBFromRequestUnmarshaller(ErrorResource)
+}

--- a/src/main/scala/com/akkaapitemplate/infrastructure/validation/RejectionCategory.scala
+++ b/src/main/scala/com/akkaapitemplate/infrastructure/validation/RejectionCategory.scala
@@ -1,0 +1,7 @@
+package com.akkaapitemplate.infrastructure.validation
+
+object RejectionCategory extends Enumeration {
+  type RejectionCategory = Value
+  val VALIDATION = Value("VALIDATION")
+  val INTERNAL = Value("INTERNAL")
+}

--- a/src/main/scala/com/akkaapitemplate/infrastructure/validation/ValidationRules.scala
+++ b/src/main/scala/com/akkaapitemplate/infrastructure/validation/ValidationRules.scala
@@ -1,0 +1,22 @@
+package com.akkaapitemplate.infrastructure.validation
+
+import com.osinka.i18n.{Lang, Messages}
+import RejectionCategory._
+
+trait ValidationRules {
+
+  implicit val userLang = Lang("pt")
+
+  def notEmpty[T](value: String, target: String): (T) => (Boolean, Rejection) = {
+    obj => (value.trim.nonEmpty, Rejection(VALIDATION, target, Messages("validation.required", Messages(target)), "validation.required", List(target)))
+  }
+
+  def ensure[T](condition: Boolean, target: String, i18nKey: String): (T) => (Boolean, Rejection) = {
+    obj => (condition, Rejection(VALIDATION, target, Messages(i18nKey), i18nKey))
+  }
+
+  def between[T](value: Double, min: Double, max: Double, target: String): (T) => (Boolean, Rejection) = {
+    obj => (value >= min && value <= max, Rejection(VALIDATION, target, Messages("validation.between", Messages(target), min, max), "validation.between", List(target, min, max)))
+  }
+
+}

--- a/src/main/scala/com/akkaapitemplate/infrastructure/validation/Validator.scala
+++ b/src/main/scala/com/akkaapitemplate/infrastructure/validation/Validator.scala
@@ -1,0 +1,35 @@
+package com.akkaapitemplate.infrastructure.validation
+
+import algebra.Semigroup
+import cats.data.Validated._
+import cats.data.ValidatedNel
+import cats.implicits._
+import com.akkaapitemplate.infrastructure.validation.RejectionCategory.RejectionCategory
+
+object Validator {
+  def validate[T](value: T, rules: List[Rule[T]]): List[Rejection] = {
+    implicit val semigroup = new Semigroup[T] {
+      override def combine(x: T, y: T): T = x
+    }
+
+    def executeRule(rule: Rule[T]): ValidatedNel[Rejection, T] = rule.validate(value) match {
+      case (condition, message) => if (condition) valid(value) else invalidNel(message)
+    }
+
+    val result = rules match {
+      case x :: xs => xs.foldLeft(executeRule(x)) { case (z, n) => z.combine(executeRule(n)) }
+      case Nil => valid(value)
+    }
+
+    result match {
+      case Valid(v) => List()
+      case Invalid(rejections) => rejections.unwrap
+    }
+  }
+}
+
+case class Rejection(category: RejectionCategory, target: String, message: String, key: String, args: List[Any] = List()) {
+  def identifier = List(category.toString, target, message).mkString(".")
+}
+
+case class Rule[T](validate: T => (Boolean, Rejection))

--- a/src/test/scala/com/akkaapitemplate/components/user/UserRepositoryActorSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/components/user/UserRepositoryActorSpec.scala
@@ -5,50 +5,78 @@ import scala.concurrent.Future
 import akka.actor.Props
 import akka.actor.Status.Failure
 import akka.testkit.{TestActorRef, TestKit}
-import com.akkaapitemplate.components.user.ActorMessages.{Fail, LoadById}
+import com.akkaapitemplate.components.user.ActorMessages.{Create, Fail, LoadById}
 import com.akkaapitemplate.infrastructure.generators.user.UserGenerator
 import com.akkaapitemplate.infrastructure.test.ActorSpec
 import java.util.UUID
 
 class UserRepositoryActorSpec extends ActorSpec with UserGenerator {
 
-  override def afterAll () = TestKit.shutdownActorSystem(system)
+  "The UserRepositoryActor" when {
+    "LoadById message" should {
+      "load user from repository" in {
+        val (userRepository, userRepositoryActor) = setUp()
+        val user = userGen.sample.get
+        (userRepository.loadById _).when(user.id.get).returns(Future.successful(Some(user)))
 
-  "The UserRepositoryActor" must {
-    "load user from repository on LoadById message" in {
-      val (userRepository, userRepositoryActor) = setUp()
-      val user = userGen.sample.get
-      (userRepository.loadById _).when(user.id.get).returns(Future.successful(Some(user)))
+        userRepositoryActor ! LoadById(requestId = UUID.randomUUID(), id = user.id.get)
 
-      userRepositoryActor ! LoadById(requestId = UUID.randomUUID(), id = user.id.get)
+        expectMsg(Some(user))
+      }
 
-      expectMsg(Some(user))
-    }
+      "send Failure message on repository load fail" in {
+        val (userRepository, userRepositoryActor) = setUp()
+        val id = UUID.randomUUID()
+        val exception = new RuntimeException
+        (userRepository.loadById _).when(id).returns(Future.failed(exception))
 
-    "send Failure message on repository load fail" in {
-      val (userRepository, userRepositoryActor) = setUp()
-      val id = UUID.randomUUID()
-      val exception = new RuntimeException
-      (userRepository.loadById _).when(id).returns(Future.failed(exception))
+        userRepositoryActor ! LoadById(requestId = UUID.randomUUID(), id = id)
 
-      userRepositoryActor ! LoadById(requestId = UUID.randomUUID(), id = id)
-
-      expectMsg(Failure(exception))
-    }
-
-    "crash on Fail message" in {
-      val (userRepositoryMock, _) = setUp()
-      val actorRef = TestActorRef(new UserRepositoryActor(userRepositoryMock))
-      val exception = new RuntimeException
-      intercept[RuntimeException] {
-        actorRef.receive(Fail(exception))
+        expectMsg(Failure(exception))
       }
     }
 
-    "not handle unknown message" in {
-      val (_, userRepositoryActor) = setUp()
-      userRepositoryActor ! "unknown message"
-      expectNoMsg
+    "Create message" should {
+      "add user in repository" in {
+        val (userRepository, userRepositoryActor) = setUp()
+        val user = userGen.sample.get
+        val addedUser = user.copy(id = Some(UUID.randomUUID()))
+
+        (userRepository.add _).when(user).returns(Future.successful(addedUser))
+        userRepositoryActor ! Create(requestId = UUID.randomUUID(), user = user)
+
+        expectMsg(Right(addedUser))
+      }
+
+      "send Failure message on repository add fail" in {
+        val (userRepository, userRepositoryActor) = setUp()
+        val user = userGen.sample.get
+        val exception = new RuntimeException
+        (userRepository.add _).when(user).returns(Future.failed(exception))
+
+        userRepositoryActor ! Create(requestId = UUID.randomUUID(), user = user)
+
+        expectMsg(Failure(exception))
+      }
+    }
+
+    "Fail message" should {
+      "crash" in {
+        val (userRepositoryMock, _) = setUp()
+        val actorRef = TestActorRef(new UserRepositoryActor(userRepositoryMock))
+        val exception = new RuntimeException
+        intercept[RuntimeException] {
+          actorRef.receive(Fail(exception))
+        }
+      }
+    }
+
+    "Unknown message" should {
+      "not be handled" in {
+        val (_, userRepositoryActor) = setUp()
+        userRepositoryActor ! "unknown message"
+        expectNoMsg
+      }
     }
   }
 

--- a/src/test/scala/com/akkaapitemplate/components/user/UserRepositorySpec.scala
+++ b/src/test/scala/com/akkaapitemplate/components/user/UserRepositorySpec.scala
@@ -3,17 +3,35 @@ package com.akkaapitemplate.components.user
 import com.akkaapitemplate.infrastructure.generators.user.UserGenerator
 import com.akkaapitemplate.infrastructure.persistence.postgres.PostgresDriver.api._
 import com.akkaapitemplate.infrastructure.test.IntegrationSpec
-import org.scalatest.concurrent.ScalaFutures._
+import java.util.UUID
 
 class UserRepositorySpec extends IntegrationSpec with UserGenerator {
 
-  "The UserRepository" must {
-    "load user by id" in {
-      val user = userGen.sample.get
-      db.run(UserRepository.table += user)
+  "The UserRepository" when {
+    "loadById" should {
+      "return existing user" in {
+        val user = userGen.sample.get
+        db.run(UserRepository.table += user)
 
-      whenReady(UserRepository.loadById(user.id.get)) { result =>
-        result shouldEqual Some(user)
+        whenReady(UserRepository.loadById(user.id.get)) { result =>
+          result shouldEqual Some(user)
+        }
+      }
+
+      "return nonexistent" in {
+        whenReady(UserRepository.loadById(UUID.randomUUID())) { result =>
+          result shouldEqual None
+        }
+      }
+    }
+
+    "add" should {
+      "return added user" in {
+        val user = userGen.sample.get
+        whenReady(UserRepository.add(user)) { result =>
+          result.id should not be empty
+          result.name should not be empty
+        }
       }
     }
   }

--- a/src/test/scala/com/akkaapitemplate/components/user/UserRouteSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/components/user/UserRouteSpec.scala
@@ -4,49 +4,81 @@ import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes._
-import akka.util.{ByteString, Timeout}
+import akka.util.Timeout
 import com.akkaapitemplate.infrastructure.generators.user.UserGenerator
 import com.akkaapitemplate.infrastructure.persistence.postgres.PostgresDriver.api._
 import com.akkaapitemplate.infrastructure.test.RouteSpec
-import com.akkaapitemplate.resources.UserResource
-import com.google.protobuf.CodedInputStream
-import com.trueaccord.scalapb.json.JsonFormat
+import com.akkaapitemplate.resources.{RejectionsResource, UserResource}
 import java.util.UUID
+import com.akkaapitemplate.infrastructure.validation.ValidationRulesUtil._
 
 class UserRouteSpec extends RouteSpec with UserRoute with UserGenerator {
 
   def actorSystem: ActorSystem = system
   override val timeout = Timeout(5.second)
 
-  "The UserRoute" must {
-    "load user by id with json" in {
-      val user = userGen.sample.get
-      db.run(UserRepository.table += user)
+  "The UserRoute" when {
+    "load user by id" should {
+      "return existing user with json" in {
+        val user = userGen.sample.get
+        db.run(UserRepository.table += user)
 
-      Get(s"/users/${user.id.get}").addHeader(acceptJson) ~> routes ~> check {
-        status shouldEqual OK
-        response.entity.dataBytes.map { bytes =>
-          val json = bytes.decodeString(ByteString.UTF_8)
-          JsonFormat.fromJsonString(json)(UserResource.messageCompanion)
+        Get(s"/users/${user.id.get}").addHeader(acceptJson) ~> routes ~> check {
+          status shouldEqual OK
+          responseAs[UserResource] shouldEqual UserResource(user.id.get.toString, user.name)
+        }
+      }
+
+      "return existing user with proto" in {
+        val user = userGen.sample.get
+        db.run(UserRepository.table += user)
+
+        Get(s"/users/${user.id.get}").addHeader(acceptProto) ~> routes ~> check {
+          status shouldEqual OK
+          responseAs[UserResource] shouldEqual UserResource(user.id.get.toString, user.name)
+        }
+      }
+
+      "return not found for nonexistent user" in {
+        Get(s"/users/${UUID.randomUUID()}") ~> routes ~> check {
+          status shouldEqual NotFound
         }
       }
     }
 
-    "load user by id with proto" in {
-      val user = userGen.sample.get
-      db.run(UserRepository.table += user)
+    "add user" should {
+      "add user with json" in {
+        val user = userGen.sample.get
+        val resource = UserResource(user.id.get.toString, user.name)
 
-      Get(s"/users/${user.id.get}").addHeader(acceptProto) ~> routes ~> check {
-        status shouldEqual OK
-        response.entity.dataBytes.map { bytes =>
-          UserResource.parseFrom(CodedInputStream.newInstance(bytes.asByteBuffer)) shouldEqual UserResource(user.id.get.toString, user.name)
+        Post("/users", resource).addHeader(acceptJson).addHeader(contentJson) ~> routes ~> check {
+          status shouldEqual Created
+          val response = responseAs[UserResource]
+          response.id should not be empty
+          response.name shouldEqual user.name
         }
       }
-    }
 
-    "return not found for nonexistent user" in {
-      Get(s"/users/${UUID.randomUUID()}") ~> routes ~> check {
-        status shouldEqual NotFound
+      "add user with proto" in {
+        val user = userGen.sample.get
+        val resource = UserResource(user.id.get.toString, user.name)
+
+        Post("/users", resource).addHeader(acceptProto).addHeader(contentProto) ~> routes ~> check {
+          status shouldEqual Created
+          val response = responseAs[UserResource]
+          response.id should not be empty
+          response.name shouldEqual user.name
+        }
+      }
+
+      "return rejections when missing required field" in {
+        val user = userGen.sample.get.copy(name = "")
+        val resource = UserResource(user.id.get.toString, user.name)
+
+        Post("/users", resource).addHeader(acceptProto).addHeader(contentProto) ~> routes ~> check {
+          status shouldEqual BadRequest
+          responseAs[RejectionsResource].errors shouldEqual Vector(requiredRejectionResourceFor("user.name"))
+        }
       }
     }
   }

--- a/src/test/scala/com/akkaapitemplate/components/user/UserServiceActorSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/components/user/UserServiceActorSpec.scala
@@ -2,37 +2,67 @@ package com.akkaapitemplate.components.user
 
 import akka.actor.{Props, Terminated}
 import akka.testkit.TestProbe
-import com.akkaapitemplate.components.user.ActorMessages.LoadById
+import com.akkaapitemplate.components.user.ActorMessages.{Create, LoadById}
+import com.akkaapitemplate.infrastructure.generators.user.UserGenerator
 import com.akkaapitemplate.infrastructure.test.ActorSpec
+import com.akkaapitemplate.infrastructure.validation.ValidationRulesUtil._
 import java.util.UUID
 
-class UserServiceActorSpec extends ActorSpec {
+class UserServiceActorSpec extends ActorSpec with UserGenerator {
 
-  "The UserServiceActor" must {
-    "forward LoadById message to UserRepositoryActor" in {
-      val (probe, serviceActor) = setUp()
-      serviceActor ! LoadById(requestId = UUID.randomUUID(), id = UUID.randomUUID())
-      probe.expectMsgType[LoadById]
+  "The UserServiceActor" when {
+    "LoadById message" should {
+      "forward message to UserRepositoryActor" in {
+        val (userRepositoryActor, _, serviceActor) = setUp()
+        serviceActor ! LoadById(requestId = UUID.randomUUID(), id = UUID.randomUUID())
+        userRepositoryActor.expectMsgType[LoadById]
+      }
     }
 
-    "re-create UserRepositoryActor on Terminated message" in {
-      val (probe, serviceActor) = setUp()
-      serviceActor ! Terminated(serviceActor)(true, true)
-      probe.expectNoMsg
+    "Create message" should {
+      "forward message to UserRepositoryActor on validation succeeded" in {
+        val (userRepositoryActor, userValidator, serviceActor) = setUp()
+        val user = userGen.sample.get
+        //val rejections = List(requiredRejectionFor("user.name"))
+        (userValidator.validate _).when(user).returns(List())
+        serviceActor ! Create(requestId = UUID.randomUUID(), user = user)
+        userRepositoryActor.expectMsgType[Create]
+      }
+
+      "reply message to sender with validation rejections" in {
+        val (_, userValidator, serviceActor) = setUp()
+        val senderActor = TestProbe()
+        val user = userGen.sample.get
+        val rejections = List(requiredRejectionFor("user.name"))
+        (userValidator.validate _).when(user).returns(rejections)
+        serviceActor ! Create(UUID.randomUUID(), Some(senderActor.ref), user)
+        senderActor.expectMsg(Left(rejections))
+      }
     }
 
-    "not handle unknown message" in {
-      val (probe, serviceActor) = setUp()
-      serviceActor ! "unknown message"
-      probe.expectNoMsg
+    "Terminated message" should {
+      "re-create UserRepositoryActor" in {
+        val (probe, _, serviceActor) = setUp()
+        serviceActor ! Terminated(serviceActor)(true, true)
+        probe.expectNoMsg
+      }
+    }
+
+    "Unknown message" should {
+      "not be handled" in {
+        val (userRepositoryActor, _, serviceActor) = setUp()
+        serviceActor ! "unknown message"
+        userRepositoryActor.expectNoMsg
+      }
     }
   }
 
   private def setUp() = {
-    val probe = TestProbe()
-    val serviceActor = system.actorOf(Props(new UserServiceActor(Some(probe.ref))))
+    val userRepositoryActor = TestProbe()
+    val userValidator = stub[UserValidator]
+    val serviceActor = system.actorOf(Props(new UserServiceActor(Some(userRepositoryActor.ref), userValidator)))
 
-    (probe, serviceActor)
+    (userRepositoryActor, userValidator, serviceActor)
   }
 
 }

--- a/src/test/scala/com/akkaapitemplate/components/user/UserValidatorSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/components/user/UserValidatorSpec.scala
@@ -1,0 +1,19 @@
+package com.akkaapitemplate.components.user
+
+import com.akkaapitemplate.infrastructure.generators.user.UserGenerator
+import com.akkaapitemplate.infrastructure.test.UnitSpec
+import com.akkaapitemplate.infrastructure.validation.ValidationRulesUtil._
+
+class UserValidatorSpec extends UnitSpec with UserGenerator {
+
+  "The UserValidator" must {
+    "require name" in {
+      val user = userGen.sample.get.copy(name = "")
+      val rejections = UserValidator.validate(user)
+
+      rejections.size shouldEqual 1
+      rejections(0) shouldEqual requiredRejectionFor("user.name")
+    }
+  }
+
+}

--- a/src/test/scala/com/akkaapitemplate/infrastructure/test/RouteSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/infrastructure/test/RouteSpec.scala
@@ -1,11 +1,13 @@
 package com.akkaapitemplate.infrastructure.test
 
 import akka.http.scaladsl.model.MediaType.Compressible
-import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.headers.{Accept, `Content-Type`}
 import akka.http.scaladsl.model.{MediaType, MediaTypes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 
 trait RouteSpec extends IntegrationSpec with ScalatestRouteTest {
   val acceptJson = Accept(MediaTypes.`application/json`)
   val acceptProto = Accept(MediaType.applicationBinary("x-protobuf", Compressible, "proto"))
+  val contentJson = `Content-Type`(MediaTypes.`application/json`)
+  val contentProto = `Content-Type`(MediaType.applicationBinary("x-protobuf", Compressible, "proto"))
 }

--- a/src/test/scala/com/akkaapitemplate/infrastructure/validation/ValidationRulesUtil.scala
+++ b/src/test/scala/com/akkaapitemplate/infrastructure/validation/ValidationRulesUtil.scala
@@ -1,0 +1,24 @@
+package com.akkaapitemplate.infrastructure.validation
+
+import com.osinka.i18n.{Lang, Messages}
+import RejectionCategory._
+import com.akkaapitemplate.resources.RejectionResource
+
+object ValidationRulesUtil {
+  implicit val userLang = Lang("pt")
+
+  def requiredRejectionFor(target: String): Rejection = {
+    Rejection(VALIDATION, target, Messages("validation.required", Messages(target)), "validation.required", List(target))
+  }
+
+  def requiredRejectionResourceFor(target: String): RejectionResource = {
+    val rejection = requiredRejectionFor(target)
+    RejectionResource(
+      rejection.category.toString,
+      rejection.target,
+      rejection.message,
+      rejection.key,
+      rejection.args.map(_.toString)
+    )
+  }
+}

--- a/src/test/scala/com/akkaapitemplate/infrastructure/validation/ValidatorSpec.scala
+++ b/src/test/scala/com/akkaapitemplate/infrastructure/validation/ValidatorSpec.scala
@@ -1,0 +1,62 @@
+package com.akkaapitemplate.infrastructure.validation
+
+import com.akkaapitemplate.infrastructure.test.UnitSpec
+import RejectionCategory._
+
+class ValidatorSpec extends UnitSpec {
+
+  "The Validator" must {
+    "validate rule" in {
+      val emptyStringToBeValidated = ""
+      val rules: List[Rule[String]] = List(
+        Rule(value => (!value.isEmpty, Rejection(VALIDATION, "name", "name can't be empty", "name")))
+      )
+
+      val rejections = Validator.validate(emptyStringToBeValidated, rules)
+
+      rejections.size shouldBe 1
+      rejections.head.category shouldBe VALIDATION
+      rejections.head.target shouldBe "name"
+      rejections.head.message shouldBe "name can't be empty"
+    }
+
+    "validate multiple rules" in {
+      val passwordToBeValidated = "12345"
+      val rules: List[Rule[String]] = List(
+        Rule(value => (value.size >= 6, Rejection(VALIDATION, "password", "password should have at least 6 characters", "password"))),
+        Rule(value => (value.matches("[a-zA-Z]") && value.matches("[0-9]"), Rejection(VALIDATION, "password", "password should have numbers and letters", "password")))
+      )
+
+      val rejections = Validator.validate(passwordToBeValidated, rules)
+
+      rejections.size shouldBe 2
+      rejections(0).category shouldBe VALIDATION
+      rejections(0).target shouldBe "password"
+      rejections(0).message shouldBe "password should have at least 6 characters"
+      rejections(1).category shouldBe VALIDATION
+      rejections(1).target shouldBe "password"
+      rejections(1).message shouldBe "password should have numbers and letters"
+    }
+
+    "return empty list for no rules" in {
+      val value = "12345"
+      val rules: List[Rule[String]] = List()
+
+      val rejections = Validator.validate(value, rules)
+
+      rejections shouldBe empty
+    }
+
+    "return empty list for valid value" in {
+      val passwordToBeValidated = "123456"
+      val rules: List[Rule[String]] = List(
+        Rule(value => (value.size >= 6, Rejection(VALIDATION, "password", "password should have at least 6 characters", "password")))
+      )
+
+      val rejections = Validator.validate(passwordToBeValidated, rules)
+
+      rejections shouldBe empty
+    }
+  }
+
+}


### PR DESCRIPTION
Endpoint to create user with request unmarshalling and validation
support. Also add error handling to return requestId with some
information message when internal server errors occur.

closes https://github.com/nykolaslima/akka-api-template/issues/10