### PR TITLE
Remove user creation from init.sql

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ dependencies:
 test:
   override:
     - sudo service postgresql stop
-    - docker-compose up -d
     - make test
 
 deployment:

--- a/src/main/resources/db/init.sql
+++ b/src/main/resources/db/init.sql
@@ -1,3 +1,1 @@
 CREATE DATABASE akkaapitemplate;
-
-CREATE user postgres with password 'postgres';


### PR DESCRIPTION
The postgres image start by default with a user named `postgres` and our
init.sql was trying to create a user with the same name and it throws a
error that avoid the container from being initialized.
